### PR TITLE
Add CLI params for TLS cert and key - serves over HTTPS

### DIFF
--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -178,6 +178,16 @@ def setup_parser_arguments(parser):
         default=None,
         help='Turn on Basic Auth for the web interface. Should be supplied in the following format: username:password'
     )
+    web_ui_group.add_argument(
+        '--tls-cert',
+        default="",
+        help="Optional path to TLS certificate to use to serve over HTTPS"
+    )
+    web_ui_group.add_argument(
+        '--tls-key',
+        default="",
+        help="Optional path to TLS private key to use to serve over HTTPS"
+    )
     
     master_group = parser.add_argument_group(
         "Master options", 

--- a/locust/env.py
+++ b/locust/env.py
@@ -116,7 +116,7 @@ class Environment:
             master_port=master_port,
         )
     
-    def create_web_ui(self, host="", port=8089, auth_credentials=None):
+    def create_web_ui(self, host="", port=8089, auth_credentials=None, tls_cert=None, tls_key=None):
         """
         Creates a :class:`WebUI <locust.web.WebUI>` instance for this Environment and start running the web server
         
@@ -125,5 +125,5 @@ class Environment:
         :param port: Port that the web server should listen to
         :param auth_credentials: If provided (in format "username:password") basic auth will be enabled
         """
-        self.web_ui = WebUI(self, host, port, auth_credentials=auth_credentials)
+        self.web_ui = WebUI(self, host, port, auth_credentials=auth_credentials, tls_cert=tls_cert, tls_key=tls_key)
         return self.web_ui

--- a/locust/main.py
+++ b/locust/main.py
@@ -224,14 +224,16 @@ def main():
     # start Web UI
     if not options.headless and not options.worker:
         # spawn web greenlet
-        logger.info("Starting web monitor at http://%s:%s" % (options.web_host, options.web_port))
+        protocol = "https" if options.tls_cert and options.tls_key else "http"
+        logger.info("Starting web monitor at %s://%s:%s" % (protocol, options.web_host, options.web_port))
         try:
             if options.web_host == "*":
                 # special check for "*" so that we're consistent with --master-bind-host
                 web_host = ''
             else:
                 web_host = options.web_host
-            web_ui = environment.create_web_ui(host=web_host, port=options.web_port, auth_credentials=options.web_auth)
+            web_ui = environment.create_web_ui(
+                host=web_host, port=options.web_port, auth_credentials=options.web_auth, tls_cert=options.tls_cert, tls_key=options.tls_key)
         except AuthCredentialsError:
             logger.error("Credentials supplied with --web-auth should have the format: username:password")
             sys.exit(1)


### PR DESCRIPTION
This adds support for serving the web UI over HTTPS. This shouldn't be the default behavior probably but if you have a cert I think you should be able to use it. Especially if basic auth is enabled.

This was first attempted and closed several years ago in #285. I'm hoping that it can be readdressed today though. Most of the web is moving to HTTPS and I believe anything that ships a web server should also come with the ability to run it securely - especially with a package as widely used as Locust is.

Comments/feedback/suggestions welcome, happy to iterate and make this work however we can! I love the Locust project and am happy to help improve it.